### PR TITLE
fix: display invited users in board automations and filters

### DIFF
--- a/epitrello/src/components/board/AutomationModal.tsx
+++ b/epitrello/src/components/board/AutomationModal.tsx
@@ -123,7 +123,8 @@ export function AutomationModal({ isOpen, onClose, boardId, lists, onInvite, cur
         try {
             const res = await fetch(`/api/boards/${boardId}/members`);
             if (res.ok) {
-                setMembers(await res.json());
+                const data = await res.json();
+                setMembers(data.members || []);
             }
         } catch (error) {
             console.error("Failed to load members", error);


### PR DESCRIPTION
The API endpoint /api/boards/[boardId]/members returns an object with a 'members' property, but AutomationModal was expecting a direct array. This prevented invited users (observers or editors) from appearing in the automation and filter user lists.

Fixed by properly extracting the 'members' array from the API response.